### PR TITLE
Fix a typo in a path in the resources definition.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ lib64
 pip-log.txt
 
 # Unit test / coverage reports
+.cache
 .coverage
 .tox
 nosetests.xml

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 CHANGES
 =======
 
-4.0.5 (unreleased)
+4.0.4-1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a typo in a path in the resources definition.
 
 
 4.0.4 (2017-10-08)

--- a/js/select2/__init__.py
+++ b/js/select2/__init__.py
@@ -6,7 +6,7 @@ library = fanstatic.Library('select2', 'resources')
 select2_css = fanstatic.Resource(
     library,
     'css/select2.css',
-    minified='js/select2.min.css')
+    minified='css/select2.min.css')
 
 select2 = fanstatic.Resource(
     library, 'js/select2.js',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '4.0.5.dev0'
+version = '4.0.4-1.dev0'
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist =
+    py27,
+    py36,
+
+[testenv]
+deps =
+    .
+    pytest
+commands =
+    pytest


### PR DESCRIPTION
Add `tox.ini` to be able to run the tests of the package to prevent such bugs in future.